### PR TITLE
Add "full" pool_mode

### DIFF
--- a/biotransformers/wrappers/transformers_wrappers.py
+++ b/biotransformers/wrappers/transformers_wrappers.py
@@ -523,7 +523,7 @@ class TransformersWrapper(ABC):
         Returns:
             torch.Tensor: Tensor of shape [number_of_sequences, embeddings_size]
         """
-        if "full" in pool_mode and not all(len(s) == len(sequences[0]) for s in sequences):
+        if "full" in pool_mode and not all(len(s) == len(sequences_list[0]) for s in sequences_list):
             raise Exception("Sequences must be of same length when pool_mode = (\"full\",)")
         
         if tokens_list is None:

--- a/biotransformers/wrappers/transformers_wrappers.py
+++ b/biotransformers/wrappers/transformers_wrappers.py
@@ -319,6 +319,11 @@ class TransformersWrapper(ABC):
                 [torch.min(emb.float(), 0)[0] for emb in embeddings]
             )
 
+        if "full" in pool_mode:
+            embeddings_dict["full"] = torch.stack(
+                [emb.float() for emb in embeddings]
+            )
+
         return embeddings_dict
 
     def _model_evaluation(

--- a/biotransformers/wrappers/transformers_wrappers.py
+++ b/biotransformers/wrappers/transformers_wrappers.py
@@ -523,6 +523,9 @@ class TransformersWrapper(ABC):
         Returns:
             torch.Tensor: Tensor of shape [number_of_sequences, embeddings_size]
         """
+        if "full" in pool_mode and not all(len(s) == len(sequences[0]) for s in sequences):
+            raise Exception("Sequences must be of same length when pool_mode = (\"full\",)")
+        
         if tokens_list is None:
             tokens_list = NATURAL_AAS_LIST
 


### PR DESCRIPTION
Add option to select "full" as a `pool_mode` for ProtBert embeddings.

The "full" option returns the full sequence of embeddings, rather than a reduced version using mean, cls, max, etc. The returned shape when using `pool_mode=["full"]` is `(num_seqs, seq_size, emb_size)`

Note: currently when using full, all sequences need to be of the same length.